### PR TITLE
Updating youtube.hide-recommendedforyou.user.js

### DIFF
--- a/YouTube/youtube.hide-recommendedforyou.user.js
+++ b/YouTube/youtube.hide-recommendedforyou.user.js
@@ -1,11 +1,15 @@
 // ==UserScript==
-// @name       YouTube Hide "Recommended for you" from related videos
-// @namespace  http://mathemaniac.org/
-// @version    1.0
-// @description  Hides videos marked as "Recommended for you" from the related videos on YouTube video pages.
-// @match      http://*youtube.com/watch*
-// @copyright  2013, Sebastian Paaske Tørholm
-// @require      http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js
+// @name        YouTube Hide "Recommended for you" from related videos
+// @namespace   http://mathemaniac.org/
+// @version     1.0b
+// @description Hides videos marked as "Recommended for you" from the related videos on YouTube video pages.
+// @include     http://youtube.com/watch*
+// @include     http://www.youtube.com/watch*
+// @include     https://youtube.com/watch*
+// @include     https://www.youtube.com/watch*
+// @grant       none
+// @copyright   2013, Sebastian Paaske Tørholm
+// @require     http://code.jquery.com/jquery-latest.min.js
 // ==/UserScript==
 
 function hideRecommended() {


### PR DESCRIPTION
I found your script in greasyfork, unfortunately the script is outdated. This is a simple patch to make it work again.

The greasyfork page: https://greasyfork.org/en/scripts/4599-youtube-hide-recommended-for-you-from-related-videos

PS: thanks for the script! I was so freaking annoyed with the "Recommended for you" videos
